### PR TITLE
Fix for broken "Solar System of JS" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
           <li>Remember <a href="http://www.gwtproject.org/">GWT</a>, and <a href="http://www.openlaszlo.org/">OpenLaszlo</a> before it?</li>
           <li><a href="http://coffeescript.org/">CoffeeScript</a>, now hundreds of compile-to-JS languages</li>
           <li>(including <a href="http://dartlang.org/">Dart</a>)</li>
-          <li>See the <a href="shaunlebron.github.io/solar-system-of-js/">Solar System of JS</a></li>
+          <li>See the <a href="http://shaunlebron.github.io/solar-system-of-js/">Solar System of JS</a></li>
           <li>For C++ to JS, <a href="http://kripken.github.io/mloc_emscripten_talk/">Emscripten</a> by <a href="https://twitter.com/kripken">Alon Zakai</a></li>
         </ul>
       </section>


### PR DESCRIPTION
This fixed the broken link to **Solar System of JS** this page: 
http://brendaneich.github.io/ModernWeb.tw-2015/#27

See working fix here:
http://francoislaberge.com/ModernWeb.tw-2015/#27

**NOTE** You must press the right arrow a few times to get the elements with the link to animate in on in either of those pages
